### PR TITLE
Add Privacy, Terms, Cookie, and Contact pages with footer links

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -160,6 +160,15 @@ const canonicalUrl = url || new URL(Astro.request.url).origin + Astro.request.ur
         </li>
       </ul>
       <p class="footer-copy">© {new Date().getFullYear()} EGI</p>
+      <p class="footer-links" aria-label="Legal and contact links">
+        <a href="/privacy-policy">Privacy Policy</a>
+        <span aria-hidden="true">•</span>
+        <a href="/terms-of-service">Terms of Service</a>
+        <span aria-hidden="true">•</span>
+        <a href="/cookie-policy">Cookie Policy</a>
+        <span aria-hidden="true">•</span>
+        <a href="/contact">Contact Information</a>
+      </p>
     </footer>
   </body>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,22 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Contact Information — EGI" description="Get in touch with Elemonator Games Inc. for partnerships, press, or general inquiries.">
+  <h1>Contact Information</h1>
+  <p>We would love to hear from you. Reach out to our team for co-development partnerships, press inquiries, or collaboration opportunities.</p>
+
+  <section>
+    <h2>General Inquiries</h2>
+    <p>Email: <a href="mailto:hello@elemonatorgames.com">hello@elemonatorgames.com</a></p>
+  </section>
+
+  <section>
+    <h2>Business & Partnerships</h2>
+    <p>Email: <a href="mailto:partners@elemonatorgames.com">partners@elemonatorgames.com</a></p>
+  </section>
+
+  <section>
+    <h2>Studio</h2>
+    <p>New Brunswick, Canada</p>
+  </section>
+</Base>

--- a/src/pages/cookie-policy.astro
+++ b/src/pages/cookie-policy.astro
@@ -1,0 +1,25 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Cookie Policy — EGI" description="Understand how Elemonator Games Inc. uses cookies and similar technologies.">
+  <h1>Cookie Policy</h1>
+  <p>This site uses cookies and similar technologies to keep the experience consistent and measure general site usage. You can manage cookies through your browser settings.</p>
+
+  <section>
+    <h2>Why We Use Cookies</h2>
+    <p>Cookies help us understand how visitors navigate our site, remember preferences, and improve performance. We do not use cookies to sell personal data.</p>
+  </section>
+
+  <section>
+    <h2>Types of Cookies</h2>
+    <ul>
+      <li><strong>Essential:</strong> Required for basic site functionality.</li>
+      <li><strong>Analytics:</strong> Provide aggregated insights into site traffic and engagement.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Managing Cookies</h2>
+    <p>You can disable cookies in your browser settings, but some features of the site may not work as intended if you do.</p>
+  </section>
+</Base>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -1,0 +1,27 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Privacy Policy — EGI" description="Learn how Elemonator Games Inc. collects, uses, and protects personal information.">
+  <h1>Privacy Policy</h1>
+  <p>We respect your privacy and are committed to protecting the personal information you share with Elemonator Games Inc. This policy explains what we collect, how we use it, and the choices you have.</p>
+
+  <section>
+    <h2>Information We Collect</h2>
+    <p>We may collect contact details you provide (such as your name and email address), basic analytics about how visitors use our site, and any information you choose to share when you contact us.</p>
+  </section>
+
+  <section>
+    <h2>How We Use Information</h2>
+    <p>We use your information to respond to inquiries, provide services, improve our website, and communicate updates about our work when requested.</p>
+  </section>
+
+  <section>
+    <h2>Data Protection</h2>
+    <p>We apply reasonable administrative, technical, and physical safeguards to protect your information. We only share data with trusted service providers when needed to operate this site.</p>
+  </section>
+
+  <section>
+    <h2>Your Choices</h2>
+    <p>You can request access to, correction of, or deletion of your personal data by contacting us. We will respond in a timely manner and in accordance with applicable laws.</p>
+  </section>
+</Base>

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -1,0 +1,27 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Terms of Service — EGI" description="Review the terms and conditions for using the Elemonator Games Inc. website.">
+  <h1>Terms of Service</h1>
+  <p>By accessing this website, you agree to the terms below. Please review them carefully before using our services or content.</p>
+
+  <section>
+    <h2>Use of the Site</h2>
+    <p>You may browse and share our publicly available content for personal or professional evaluation. Do not attempt to disrupt the site, misuse our content, or violate applicable laws.</p>
+  </section>
+
+  <section>
+    <h2>Intellectual Property</h2>
+    <p>All logos, artwork, and written content remain the property of Elemonator Games Inc. unless otherwise noted. Please request permission before reusing our materials for commercial purposes.</p>
+  </section>
+
+  <section>
+    <h2>Third-Party Links</h2>
+    <p>Our site links to third-party platforms like social media and distribution partners. We are not responsible for the content or practices of those sites.</p>
+  </section>
+
+  <section>
+    <h2>Changes</h2>
+    <p>We may update these terms periodically. Continued use of the site after updates indicates acceptance of the revised terms.</p>
+  </section>
+</Base>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -205,6 +205,29 @@ h1 { font-size: var(--size-h1); margin-bottom: .25rem; }
   margin-top: 1rem;
 }
 
+.footer-links {
+  margin-top: 0.35rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.6rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.footer-links a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer-links a:hover,
+.footer-links a:focus {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 @media (max-width: 600px) {
   .footer-content {
     grid-template-columns: 1fr;
@@ -224,4 +247,3 @@ h2 { font-size: var(--size-h2); margin-top: 1rem; margin-bottom: .5rem; }
 .social-link:hover, .social-link:focus { background: var(--accent); color: #000; transform: translateY(-2px); }
 .social-icon { font-size: .95rem; font-weight:700; line-height:1; display:inline-block; }
 .social-link .social-icon { width: 1.05rem; height: 1.05rem; display: block; fill: currentColor; }
-


### PR DESCRIPTION
### Motivation
- Provide accessible legal pages and contact information linked from the site footer so visitors can review policies and reach the studio.

### Description
- Added `src/pages/privacy-policy.astro`, `src/pages/terms-of-service.astro`, `src/pages/cookie-policy.astro`, and `src/pages/contact.astro` with structured content for each page.
- Added a footer link row to `src/layouts/Base.astro` that links to the new pages.
- Added styles for `.footer-links` and link hover/focus in `src/styles/tokens.css` to match footer presentation.

### Testing
- Started the dev server with `npm run dev` and the site served at `http://localhost:4321/` and returned `200` for `/`.
- Captured a screenshot of the homepage footer using Playwright (artifact: `artifacts/footer-links.png`) to verify the links render.
- No automated unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971108951a48323aaa89800b3063561)