### PR TITLE
Prefix editable copy comments for searchability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,29 @@
-# Astro Starter Kit: Minimal
+# Elemonator Games Inc. — Astro Site
 
-```sh
-npm create astro@latest -- --template minimal
-```
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+Marketing site for Elemonator Games Inc., built with Astro.
 
 ## 🚀 Project Structure
-
-**Note:** This repo received a small UI polish (Dec 2025) — contact form is now a boxed card with stacked fields, improved submit UX, and projects are displayed in a responsive card grid. See `CHANGELOG.md` or `.github/copilot-instructions.md` for testing notes and local worker instructions.
-
-
-Inside of your Astro project, you'll see the following folders and files:
 
 ```text
 /
 ├── public/
 ├── src/
-│   └── pages/
-│       └── index.astro
+│   ├── components/
+│   ├── layouts/
+│   ├── pages/
+│   │   ├── blog/
+│   │   ├── projects/
+│   │   ├── index.astro
+│   │   └── co-development.astro
+│   └── styles/
 └── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
+- **Pages** live in `src/pages/` and map to routes by filename.
+- **Static assets** (images, icons) live in `public/`.
+- **Global layout** defaults and metadata live in `src/layouts/Base.astro`.
 
 ## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
 
 | Command                   | Action                                           |
 | :------------------------ | :----------------------------------------------- |
@@ -41,9 +34,25 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 
-## 👀 Want to learn more?
+## ✍️ Content Updates
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+### Add a new project
+
+1. **Create a detail page** in `src/pages/projects/` using the existing pages as a template (e.g., `lightning.astro`).
+2. **Update the projects index** at `src/pages/projects/index.astro` by adding a new card with your project title, metadata, summary, and link.
+3. **Add imagery** under `public/` and update the project image `<img>` tag to use the new asset.
+
+### Add a new blog post
+
+1. **Create a post page** in `src/pages/blog/` (e.g., `new-post.astro`).
+2. **Update the blog index** at `src/pages/blog/index.astro` by adding a new card with the title, date, summary, and link.
+3. **Add assets** (if needed) to `public/` and reference them in the post.
+
+### Add or update co-development packages
+
+1. **Update the package cards** in `src/pages/co-development.astro` within the `card-grid` section (title, duration, summary).
+2. **Update the modal content** in the `packageDetails` object in the same file so the detailed description, inclusions, and outcomes match the card.
+3. **Keep package keys in sync** between the card `data-package` attribute and the `packageDetails` object.
 
 ## 🖼️ Assets & Icons
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,10 +5,12 @@ const currentYear = new Date().getFullYear();
   <div class="container">
     <div class="footer-content">
       <div class="footer-section">
+        <!-- Editable footer: studio name and short description -->
         <h3>Elemonator Games Inc.</h3>
         <p>New Brunswick-based game studio specializing in co-development and innovative game projects.</p>
       </div>
       <div class="footer-section">
+        <!-- Editable footer: quick navigation link labels -->
         <h4>Quick Links</h4>
         <ul>
           <li><a href="/about">About</a></li>
@@ -19,6 +21,7 @@ const currentYear = new Date().getFullYear();
         </ul>
       </div>
       <div class="footer-section">
+        <!-- Editable footer: social/contact destinations -->
         <h4>Connect</h4>
         <ul>
           <li><a href="mailto:elemonatorgames@gmail.com">Email</a></li>
@@ -29,6 +32,7 @@ const currentYear = new Date().getFullYear();
       </div>
     </div>
     <div class="footer-bottom">
+      <!-- Editable footer: copyright line -->
       <p>&copy; {currentYear} Elemonator Games Inc. All rights reserved.</p>
     </div>
   </div>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,7 +1,8 @@
 ---
 import "../styles/tokens.css";
-const { 
-  title = "Elemonator Games Inc.", 
+// Editable global metadata defaults: update when refining site-wide SEO copy or share imagery.
+const {
+  title = "Elemonator Games Inc.",
   description = "New Brunswick-based game studio helping teams ship—engineering, design, and art—plus two in-house projects.",
   ogImage = "/placeholders/800x450.svg",
   url = ""
@@ -28,6 +29,7 @@ const canonicalUrl = url || new URL(Astro.request.url).origin + Astro.request.ur
     <header role="banner" class="site-header" data-header>
       <div class="container header-inner">
         <h1 class="visually-hidden">Elemonator Games Inc.</h1>
+        <!-- Editable global header: primary navigation labels -->
         <nav aria-label="Primary" class="nav">
           <a href="/">Home</a>
           <a href="/about">About</a>
@@ -115,6 +117,7 @@ const canonicalUrl = url || new URL(Astro.request.url).origin + Astro.request.ur
       <slot />
     </main>
     <footer role="contentinfo" class="container">
+      <!-- Editable global footer: social labels and destinations -->
       <ul class="social-list" aria-label="Socials and developer spaces">
         <li>
           <a href="https://x.com/ElemonatorGames" class="social-link" aria-label="Twitter" target="_blank" rel="noopener noreferrer">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,6 +3,7 @@ import Base from "../layouts/Base.astro";
 ---
 <Base title="Page Not Found — EGI" description="Sorry, the page you're looking for doesn't exist. Return to Elemonator Games Inc. homepage.">
   <section class="card">
+    <!-- Editable 404 page: error headline and recovery links -->
     <h1>404 - Page Not Found</h1>
     <p>Sorry, the page you're looking for doesn't exist or has been moved.</p>
     <p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,15 +2,18 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="About — EGI" description="Learn about Elemonator Games Inc., our mission, and the team behind New Brunswick's premier game development studio.">
+  <!-- Editable about page: company overview headline and intro copy -->
   <h1>About Elemonator Games Inc.</h1>
   <p>Elemonator Games Inc. is a New Brunswick-based game studio dedicated to helping teams bring their game ideas to life. We specialize in co-development partnerships, providing engineering, design, and art support to turn concepts into polished products.</p>
 
   <section>
+    <!-- Editable about page: mission statement copy -->
     <h2>Our Mission</h2>
     <p>We believe in the power of games to tell stories, solve problems, and bring people together. Our mission is to empower game developers and studios with the expertise and resources they need to ship exceptional games.</p>
   </section>
 
   <section>
+    <!-- Editable about page: team member bios (duplicate article cards for additional staff) -->
     <h2>Our Team</h2>
     <div class="card-grid">
       <article class="card project-card">
@@ -18,11 +21,12 @@ import Base from "../layouts/Base.astro";
         <p class="meta">Founder & Lead Developer</p>
         <p>Experienced game developer with a passion for innovative mechanics and player experiences. Specializes in Unity, Unreal Engine, and cross-platform development.</p>
       </article>
-      <!-- Add more team members as needed -->
+      <!-- Editable about page: add additional team member cards as the roster grows -->
     </div>
   </section>
 
   <section>
+    <!-- Editable about page: studio process/approach description -->
     <h2>Our Approach</h2>
     <p>We work closely with our partners to understand their vision and deliver results that exceed expectations. From rapid prototyping to full production support, we're here to help at every stage of development.</p>
   </section>

--- a/src/pages/blog/getting-started-with-game-dev.astro
+++ b/src/pages/blog/getting-started-with-game-dev.astro
@@ -8,6 +8,7 @@ import Breadcrumb from "../../components/Breadcrumb.astro";
     { label: "Blog", href: "/blog" },
     { label: "Getting Started with Game Development" }
   ]} />
+  <!-- Editable blog post content: editorial headline, date, and article body copy -->
   <article>
     <header>
       <h1>Getting Started with Game Development</h1>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,18 +2,20 @@
 import Base from "../../layouts/Base.astro";
 ---
 <Base title="Blog — EGI" description="Read insights, tutorials, and updates from Elemonator Games Inc. on game development, co-development strategies, and industry trends.">
+  <!-- Editable blog index: page headline and intro summary -->
   <h1>Blog</h1>
   <p>Insights, tutorials, and updates from Elemonator Games Inc.</p>
 
   <div class="blog-posts-container">
     <section class="card-grid">
       <article class="card project-card">
+        <!-- Editable blog index card: post title, date, and summary -->
         <h3><a href="/blog/getting-started-with-game-dev">Getting Started with Game Development</a></h3>
         <p class="meta">January 21, 2026</p>
         <p>An introduction to the basics of game development, covering tools, concepts, and first steps for aspiring developers.</p>
       </article>
 
-      <!-- Add more posts here as needed -->
+      <!-- Editable blog index: add additional post cards here as new articles are published -->
     </section>
   </div>
 </Base>

--- a/src/pages/co-development.astro
+++ b/src/pages/co-development.astro
@@ -2,23 +2,27 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Co‑Development Packages — EGI" description="Explore our co-development packages for game studios at any stage. From discovery and prototyping to full production support and live operations.">
+  <!-- Editable co-development page: headline and intro copy describing package overview -->
   <h1>Co‑Development Packages</h1>
   <p>We partner with teams at any stage — from early ideation and prototyping through to full production support and live ops. Below are example packages and the outcomes you can expect from each engagement.</p>
 
   <section class="card-grid">
     <article class="card project-card" data-package="discovery">
+      <!-- Editable co-development package card: discovery package title and summary copy -->
       <h3>Discovery & Prototyping</h3>
       <p class="meta">2–4 week sprint</p>
       <p>Rapid concept validation with playable prototypes and a clear scope for further development. We focus on riskiest assumptions first to avoid long-term rework.</p>
     </article>
 
     <article class="card project-card" data-package="engineering">
+      <!-- Editable co-development package card: engineering package title and summary copy -->
       <h3>Engineering Sprint Support</h3>
       <p class="meta">4–12 week engagements</p>
       <p>Dedicated engineers to help with core systems, optimization, and platform integration. We pack focused milestones and demos to keep momentum without scope creep.</p>
     </article>
 
     <article class="card project-card" data-package="design">
+      <!-- Editable co-development package card: design/art package title and summary copy -->
       <h3>Design & Art Co‑Creation</h3>
       <p class="meta">Flexible scope</p>
       <p>Collaborative design sprints, art direction, and asset pipelines that fit your needs. We provide iterative deliverables and clear acceptance criteria to avoid endless scrolling.</p>
@@ -28,6 +32,7 @@ import Base from "../layouts/Base.astro";
   <div id="modal" class="modal">
     <div class="modal-content">
       <button class="modal-close" aria-label="Close modal">&times;</button>
+      <!-- Editable co-development modal: package title, timeline, and detailed description text -->
       <h2 id="modal-title"></h2>
       <p id="modal-meta"></p>
       <div id="modal-description"></div>
@@ -96,6 +101,7 @@ const modalTitle = document.getElementById('modal-title');
 const modalMeta = document.getElementById('modal-meta');
 const modalDescription = document.getElementById('modal-description');
 
+// Editable co-development modal copy: package descriptions, inclusions, and outcomes
 const packageDetails = {
   discovery: {
     description: `

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,20 +2,24 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Contact Information — EGI" description="Get in touch with Elemonator Games Inc. for partnerships, press, or general inquiries.">
+  <!-- Editable contact info page: headline and intro copy -->
   <h1>Contact Information</h1>
   <p>We would love to hear from you. Reach out to our team for co-development partnerships, press inquiries, or collaboration opportunities.</p>
 
   <section>
+    <!-- Editable contact info section: general inquiry email -->
     <h2>General Inquiries</h2>
     <p>Email: <a href="mailto:hello@elemonatorgames.com">hello@elemonatorgames.com</a></p>
   </section>
 
   <section>
+    <!-- Editable contact info section: business and partnerships email -->
     <h2>Business & Partnerships</h2>
     <p>Email: <a href="mailto:partners@elemonatorgames.com">partners@elemonatorgames.com</a></p>
   </section>
 
   <section>
+    <!-- Editable contact info section: studio location text -->
     <h2>Studio</h2>
     <p>New Brunswick, Canada</p>
   </section>

--- a/src/pages/cookie-policy.astro
+++ b/src/pages/cookie-policy.astro
@@ -2,15 +2,18 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Cookie Policy — EGI" description="Understand how Elemonator Games Inc. uses cookies and similar technologies.">
+  <!-- Editable cookie policy page: headline and intro copy -->
   <h1>Cookie Policy</h1>
   <p>This site uses cookies and similar technologies to keep the experience consistent and measure general site usage. You can manage cookies through your browser settings.</p>
 
   <section>
+    <!-- Editable cookie policy section: reasons for cookie usage -->
     <h2>Why We Use Cookies</h2>
     <p>Cookies help us understand how visitors navigate our site, remember preferences, and improve performance. We do not use cookies to sell personal data.</p>
   </section>
 
   <section>
+    <!-- Editable cookie policy section: cookie types list -->
     <h2>Types of Cookies</h2>
     <ul>
       <li><strong>Essential:</strong> Required for basic site functionality.</li>
@@ -19,6 +22,7 @@ import Base from "../layouts/Base.astro";
   </section>
 
   <section>
+    <!-- Editable cookie policy section: cookie management guidance -->
     <h2>Managing Cookies</h2>
     <p>You can disable cookies in your browser settings, but some features of the site may not work as intended if you do.</p>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "../layouts/Base.astro";
+// Editable home page metadata: SEO title, description, and social share image.
 const title = "Elemonator Games Inc. – Game Co‑Development & Projects";
 const description = "New Brunswick-based game studio helping teams ship—engineering, design, and art—plus two in-house projects. Explore co-development packages and our latest game projects.";
 const ogImage = "/placeholders/800x450.svg";
@@ -7,6 +8,7 @@ const ogImage = "/placeholders/800x450.svg";
 <Base {title} {description} {ogImage}>
   <section aria-labelledby="hero">
     <div class="card hero" aria-hidden="false">
+      <!-- Editable home hero: primary brand headline and value proposition copy -->
       <h1 id="hero">Elemonator Games Inc.</h1>
       <p>NB‑based game studio helping teams ship—engineering, design, and art—plus two in‑house projects.</p>
       <p>
@@ -18,21 +20,25 @@ const ogImage = "/placeholders/800x450.svg";
   </section>
 
   <section aria-labelledby="contact" id="contact">
+    <!-- Editable home contact section: section title and intro text for inquiry form -->
     <h2 id="contact">Contact</h2>
 
     <div class="card contact-card" role="region" aria-labelledby="contact">
       <form action="https://egi-contact-worker.elemonatorgames.workers.dev/contact" method="POST" novalidate>
         <div class="form-field">
+          <!-- Editable contact form field: requester's name -->
           <label for="name" class="label">Name</label>
           <input id="name" name="name" class="input" required autocomplete="name" />
         </div>
 
         <div class="form-field">
+          <!-- Editable contact form field: requester's email address -->
           <label for="email" class="label">Email</label>
           <input id="email" name="email" type="email" class="input" required autocomplete="email" />
         </div>
 
         <div class="form-field">
+          <!-- Editable contact form field: inquiry message details -->
           <label for="msg" class="label">Message</label>
           <textarea id="msg" name="message" class="textarea" rows="6" required></textarea>
         </div>
@@ -46,6 +52,7 @@ const ogImage = "/placeholders/800x450.svg";
           <button type="submit" class="btn btn--primary">Send</button>
         </div>
 
+        <!-- Editable contact form fallback: alternate contact copy if submission fails -->
         <p class="form-fallback">
           If this form fails, email us: <a href="mailto:elemonatorgames@gmail.com">elemonatorgames@gmail.com</a>
         </p>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -2,25 +2,30 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Privacy Policy — EGI" description="Learn how Elemonator Games Inc. collects, uses, and protects personal information.">
+  <!-- Editable privacy policy page: headline and intro copy -->
   <h1>Privacy Policy</h1>
   <p>We respect your privacy and are committed to protecting the personal information you share with Elemonator Games Inc. This policy explains what we collect, how we use it, and the choices you have.</p>
 
   <section>
+    <!-- Editable privacy policy section: information collection details -->
     <h2>Information We Collect</h2>
     <p>We may collect contact details you provide (such as your name and email address), basic analytics about how visitors use our site, and any information you choose to share when you contact us.</p>
   </section>
 
   <section>
+    <!-- Editable privacy policy section: how collected information is used -->
     <h2>How We Use Information</h2>
     <p>We use your information to respond to inquiries, provide services, improve our website, and communicate updates about our work when requested.</p>
   </section>
 
   <section>
+    <!-- Editable privacy policy section: data protection and sharing statement -->
     <h2>Data Protection</h2>
     <p>We apply reasonable administrative, technical, and physical safeguards to protect your information. We only share data with trusted service providers when needed to operate this site.</p>
   </section>
 
   <section>
+    <!-- Editable privacy policy section: user choices and contact guidance -->
     <h2>Your Choices</h2>
     <p>You can request access to, correction of, or deletion of your personal data by contacting us. We will respond in a timely manner and in accordance with applicable laws.</p>
   </section>

--- a/src/pages/projects/aurora.astro
+++ b/src/pages/projects/aurora.astro
@@ -8,9 +8,11 @@ import Breadcrumb from "../../components/Breadcrumb.astro";
     { label: "Projects", href: "/projects" },
     { label: "Project Aurora" }
   ]} />
+  <!-- Editable project detail: headline, metadata, and overview copy for Project Aurora -->
   <article class="card">
     <h1>Project Aurora</h1>
     <p class="meta">Co‑dev • Unity • Multi‑platform • 2024</p>
+    <!-- Editable project detail: placeholder hero image -->
     <img src="/placeholders/800x450.svg" alt="Project Aurora placeholder" />
     <h2>Overview</h2>
     <p>Project Aurora is a co-development project focusing on narrative-driven cooperative gameplay and a modular systems architecture that supports cross‑platform deployment.</p>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -2,11 +2,13 @@
 import Base from "../../layouts/Base.astro";
 ---
 <Base title="Projects — EGI" description="Discover our in-house game projects and co-development work. From multiplayer prototypes to narrative-driven experiences across multiple platforms.">
+  <!-- Editable projects index: page headline and filtering helper text -->
   <h1>Projects</h1>
   <p>Filter by In‑house / Co‑dev, platform, engine, year.</p>
 
   <div class="card-grid">
     <article class="project-card">
+      <!-- Editable projects index card: placeholder image and summary for Project Lightning -->
       <img src="/placeholders/800x450.svg" alt="Project Lightning placeholder image" />
       <h3>Project Lightning</h3>
       <p class="meta">In‑house • Unreal • PC • 2025</p>
@@ -15,6 +17,7 @@ import Base from "../../layouts/Base.astro";
     </article>
 
     <article class="project-card">
+      <!-- Editable projects index card: placeholder image and summary for Project Aurora -->
       <img src="/placeholders/800x450.svg" alt="Project Aurora placeholder image" />
       <h3>Project Aurora</h3>
       <p class="meta">Co‑dev • Unity • Multi‑platform • 2024</p>

--- a/src/pages/projects/lightning.astro
+++ b/src/pages/projects/lightning.astro
@@ -8,9 +8,11 @@ import Breadcrumb from "../../components/Breadcrumb.astro";
     { label: "Projects", href: "/projects" },
     { label: "Project Lightning" }
   ]} />
+  <!-- Editable project detail: headline, metadata, and overview copy for Project Lightning -->
   <article class="card">
     <h1>Project Lightning</h1>
     <p class="meta">In-house • Unreal • PC • 2025</p>
+    <!-- Editable project detail: placeholder hero image -->
     <img src="/placeholders/800x450.svg" alt="Project Lightning placeholder" />
     <h2>Overview</h2>
     <p>Project Lightning is an in‑house prototype focused on building a high-performance multiplayer experience with robust netcode and tight core gameplay loops.</p>

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -2,25 +2,30 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Terms of Service — EGI" description="Review the terms and conditions for using the Elemonator Games Inc. website.">
+  <!-- Editable terms of service page: headline and intro copy -->
   <h1>Terms of Service</h1>
   <p>By accessing this website, you agree to the terms below. Please review them carefully before using our services or content.</p>
 
   <section>
+    <!-- Editable terms of service section: acceptable use guidance -->
     <h2>Use of the Site</h2>
     <p>You may browse and share our publicly available content for personal or professional evaluation. Do not attempt to disrupt the site, misuse our content, or violate applicable laws.</p>
   </section>
 
   <section>
+    <!-- Editable terms of service section: intellectual property statement -->
     <h2>Intellectual Property</h2>
     <p>All logos, artwork, and written content remain the property of Elemonator Games Inc. unless otherwise noted. Please request permission before reusing our materials for commercial purposes.</p>
   </section>
 
   <section>
+    <!-- Editable terms of service section: third-party links disclaimer -->
     <h2>Third-Party Links</h2>
     <p>Our site links to third-party platforms like social media and distribution partners. We are not responsible for the content or practices of those sites.</p>
   </section>
 
   <section>
+    <!-- Editable terms of service section: update notice -->
     <h2>Changes</h2>
     <p>We may update these terms periodically. Continued use of the site after updates indicates acceptance of the revised terms.</p>
   </section>

--- a/src/pages/thanks.astro
+++ b/src/pages/thanks.astro
@@ -2,6 +2,7 @@
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Thanks — EGI" description="Thank you for contacting Elemonator Games Inc. We've received your message and will respond shortly.">
+  <!-- Editable confirmation page: headline and follow-up copy after contact submission -->
   <h1>Thanks!</h1>
   <p>We received your message. We’ll get back to you shortly.</p>
   <p><a href="/" class="btn">Return home</a></p>


### PR DESCRIPTION
### Motivation
- Make all in-code editable-copy annotations easy to find by a single search term so non-developers and content editors can locate and update site copy quickly.
- Ensure metadata, header/footer, page sections, form fields, and modal copy all use a consistent annotation prefix for maintainability.

### Description
- Prefixed inline comment annotations across site pages and components with the word `Editable`, updating comment markers in files such as `src/pages/index.astro`, `src/pages/about.astro`, `src/pages/blog/*`, `src/pages/projects/*`, `src/pages/co-development.astro`, `src/pages/privacy-policy.astro`, `src/pages/terms-of-service.astro`, `src/pages/contact.astro`, `src/pages/404.astro`, `src/pages/thanks.astro`, `src/layouts/Base.astro`, and `src/components/Footer.astro`.
- Standardized global metadata and layout comments in `src/layouts/Base.astro` and footer annotations in `src/components/Footer.astro` to use the same `Editable` prefix.
- Kept all changes comment/content-only with no runtime logic or functional behavior modifications.

### Testing
- No automated tests were run because this change consists solely of comment/content annotation updates and does not affect executable code or CI jobs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69711441243483239f929abb240a2a10)